### PR TITLE
remove response type

### DIFF
--- a/src/Http/Middleware/LaratronMiddleware.php
+++ b/src/Http/Middleware/LaratronMiddleware.php
@@ -39,8 +39,8 @@ final class LaratronMiddleware
 
                 $response = new Response($clientResponse->getBody());
 
-                $response->header('Content-Type', 'text/html');
-
+                $response->headers->set('Content-Type','text/html');
+               
                 return $response;
             } catch (BadResponseException $e) {
                 Log::error($e->getMessage());

--- a/src/Http/Middleware/LaratronMiddleware.php
+++ b/src/Http/Middleware/LaratronMiddleware.php
@@ -8,11 +8,11 @@ use Closure;
 use GuzzleHttp\Client;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use GuzzleHttp\Exception\BadResponseException;
+use Symfony\Component\HttpFoundation\Response;
 
 final class LaratronMiddleware
 {
@@ -23,7 +23,7 @@ final class LaratronMiddleware
      * @param  \Closure  $next
      * @return Illuminate\Http\Response
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
         $crawlerDetect = new CrawlerDetect;
 

--- a/src/Http/Middleware/LaratronMiddleware.php
+++ b/src/Http/Middleware/LaratronMiddleware.php
@@ -23,7 +23,7 @@ final class LaratronMiddleware
      * @param  \Closure  $next
      * @return Illuminate\Http\Response
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next)
     {
         $crawlerDetect = new CrawlerDetect;
 


### PR DESCRIPTION
`Return value of Sandulat\Laratron\Http\Middleware\LaratronMiddleware::handle() must be an instance of Illuminate\Http\Response, instance of Illuminate\Http\JsonResponse returned`

I use VueJS and InetriaJS.
My controllers return HTML on first access and JSON on site navigation (this is a feature of IntertiaJs for getting rid of the API).

Removing type solved my problem.

Thank!

P.S. Sorry for bad english